### PR TITLE
[wip] update to rustc_private 2023-06-10

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,60 +1,31 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use rustc::session::Session;
 use rustc::ty::TyCtxt;
 
-use rustc_metadata::cstore::CrateMetadata;
+use rustc_metadata::rmeta::decoder::CrateMetadata;
 use rustc_driver::{Compilation, Callbacks};
 use rustc_interface::interface::Compiler;
+use rustc_interface::Queries;
 
-fn find_sysroot() -> String {
-    if let Ok(sysroot) = ::std::env::var("MIRI_SYSROOT") {
-        return sysroot;
-    }
-
-    // Taken from https://github.com/Manishearth/rust-clippy/pull/911.
-    let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
-    let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
-    match (home, toolchain) {
-        (Some(home), Some(toolchain)) => format!("{}/toolchains/{}", home, toolchain),
-        _ => {
-            option_env!("RUST_SYSROOT")
-                .expect(
-                    "need to specify RUST_SYSROOT env var or use rustup or multirust",
-                )
-                .to_owned()
-        }
-    }
-}
-
-pub fn call_with_crate_tcx(mut args: Vec<String>, rlib: String, f: Box<Cb>) {
+pub fn call_with_crate_tcx(mut args: Vec<String>, rlib: String, f: Box<Cb>) -> ! {
     println!("Reading rlib {}", rlib);
-
-    let sysroot_flag = String::from("--sysroot");
-    if !args.contains(&sysroot_flag) {
-        args.push(sysroot_flag);
-        args.push(find_sysroot());
-    }
 
     args.push("-Cpanic=abort".to_string()); // otherwise we have to provide `eh_personality`
 
     println!("Rust args: {:?}", args);
-    let result = rustc_driver::report_ices_to_stderr_if_any(move || {
-        rustc_driver::run_compiler(
-            &args,
-            &mut MyCompilerCalls(f),
-            Some(Box::new(MyFileLoader(rlib.to_string())) as Box<_>),
-            None
-        )
-    }).and_then(|result| result);
-    std::process::exit(result.is_err() as i32);
+    std::process::exit(rustc_driver::catch_with_exit_code(move || {
+        let args: Vec<String> = std::env::args().collect();
+        rustc_driver::RunCompiler::new(&args, &mut MyCompilerCalls(f)).run()
+    }))
 }
 
 struct MyFileLoader(String);
 
-impl ::syntax::source_map::FileLoader for MyFileLoader {
+impl ::rustc_span::source_map::FileLoader for MyFileLoader {
     fn file_exists(&self, _: &Path) -> bool { true }
-    fn abs_path(&self, _: &Path) -> Option<PathBuf> { None }
+    fn read_binary_file(&self, _: &Path) -> std::io::Result<Vec<u8>> {
+        Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "should not need to load binary files"))
+    }
     fn read_file(&self, _: &Path) -> Result<String, ::std::io::Error> {
         Ok(format!("
         #![feature(no_core)]
@@ -68,32 +39,32 @@ impl ::syntax::source_map::FileLoader for MyFileLoader {
     }
 }
 
-type Cb = for<'a, 'tcx> Fn(TyCtxt<'a, 'tcx, 'tcx>) + Send;
+type Cb = dyn for<'tcx> Fn(TyCtxt<'tcx>) + Send;
 
 struct MyCompilerCalls(Box<Cb>);
 
 impl Callbacks for MyCompilerCalls {
-    fn after_analysis(&mut self, compiler: &Compiler) -> bool {
-        compiler.global_ctxt().unwrap().take().enter(|tcx| {
+    fn after_analysis<'tcx>(&mut self, compiler: &Compiler, queries: &'tcx Queries<'tcx>) -> Compilation {
+        queries.global_ctxt().unwrap().enter(|tcx| {
             (self.0)(tcx);
         });
-        false
+        Compilation::Stop
     }
 
 }
 
-pub fn with_crate_metadata<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, f: impl for<'b> FnOnce(&'b CrateMetadata)) {
+pub fn with_crate_metadata<'tcx>(tcx: TyCtxt<'tcx>, f: impl for<'b> FnOnce(&'b CrateMetadata)) {
     let mut extern_crate = None;
-    for item in tcx.hir().krate().items.values() {
-        match item.node {
-            ::rustc::hir::ItemKind::ExternCrate(_) => {
-                extern_crate = Some(item.hir_id);
+    for &item_id in tcx.hir().root_module().item_ids {
+        match tcx.hir().item(item_id).kind {
+            ::rustc_hir::ItemKind::ExternCrate(_) => {
+                extern_crate = Some(item_id.hir_id());
                 // Continue iterating to get the last `extern crate`
             }
             _ => {}
         }
     }
-    let ext_cnum = tcx.extern_mod_stmt_cnum(extern_crate.unwrap().owner_def_id()).unwrap();
+    let ext_cnum = tcx.extern_mod_stmt_cnum(extern_crate.unwrap().owner.def_id).unwrap();
     let crate_data = tcx.crate_data_as_rc_any(ext_cnum);
     f(crate_data.downcast_ref::<CrateMetadata>().unwrap());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,19 @@
 #![feature(rustc_private, concat_idents)]
 
-extern crate getopts;
-extern crate owning_ref;
-extern crate flate2;
 extern crate termion;
 extern crate clap;
 extern crate regex;
 
-extern crate syntax;
 extern crate rustc_data_structures;
 
-extern crate rustc;
-extern crate rustc_errors;
+extern crate rustc_middle as rustc;
 extern crate rustc_metadata;
-extern crate rustc_incremental;
 extern crate rustc_driver;
 extern crate rustc_interface;
-extern crate rustc_mir;
+extern crate rustc_session;
+extern crate rustc_hir;
+extern crate rustc_span;
+extern crate rustc_expand;
 
 use clap::{Arg, App};
 
@@ -39,7 +36,6 @@ fn main() {
             .subcommands(print::subcommands())
             .get_matches();
         let rlib = matches.value_of("CRATE").unwrap().to_string();
-        //let args = ::std::env::args().collect::<Vec<_>>();
         let args = vec![rlib.clone(), "/some_nonexistent_dummy_path".to_string()];
         driver::call_with_crate_tcx(args, rlib, Box::new(move |tcx| {
             driver::with_crate_metadata(tcx, |metadata| {


### PR DESCRIPTION
current errors:
```
 1  error[E0432]: unresolved import `rustc_hir::def_id::DefIndexAddressSpace`
  --> src/print.rs:8:52
 2  error[E0603]: module `rmeta` is private
  --> src/driver.rs:5:21
  --> /home/jyn/.local/lib/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/compiler/rustc_metadata/src/lib.rs:36:1
 3  error[E0603]: module `rmeta` is private
  --> src/print.rs:9:21
  --> /home/jyn/.local/lib/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/compiler/rustc_metadata/src/lib.rs:36:1
 4  error[E0599]: no method named `crate_data_as_rc_any` found for struct `TyCtxt<'tcx>` in the current scope
   --> src/driver.rs:88:26
 5  error[E0618]: expected function, found `impl for<'b> FnOnce(&'b CrateMetadata)`
   --> src/driver.rs:89:5
 6  error[E0599]: no function or associated item named `from_array_index` found for struct `DefIndex` in the current scope
    --> src/print.rs:312:31
```

some of these are just because `CrateMetadata` is private now and its methods are on TyCtxt, but some of them are real - `DefIndex` has no public constructors anymore and `CrateRoot` is private to `rustc_metadata`.